### PR TITLE
fix: guard autosave until workspace state has hydrated

### DIFF
--- a/components/sovereign-dashboard.tsx
+++ b/components/sovereign-dashboard.tsx
@@ -326,10 +326,17 @@ export function SovereignDashboard({ demoMode = false }: { demoMode?: boolean } 
     }
   }, [applyTheme]);
 
+  /** Which workspace's state has finished loading. The autosave effect must
+      not persist anything for a workspace that hasn't hydrated yet — otherwise
+      defaultState races the async load and overwrites real data (worst with
+      cloud sync, where load and save are both network calls). */
+  const hydratedWsRef = useRef<string | null>(null);
+
   /** Load app state for active workspace */
   useEffect(() => {
     if (demoMode || !activeWsId) return;
     let mounted = true;
+    hydratedWsRef.current = null;
     const key = storageKeyForWorkspace(activeWsId);
     loadSovereignValue<AppState>(key, defaultState).then((data) => {
       if (mounted) {
@@ -369,6 +376,7 @@ export function SovereignDashboard({ demoMode = false }: { demoMode?: boolean } 
         if (merged.activeProviders.length === 0) {
           merged.activeProviders = [merged.provider];
         }
+        hydratedWsRef.current = activeWsId;
         setState(merged);
       }
     });
@@ -379,6 +387,8 @@ export function SovereignDashboard({ demoMode = false }: { demoMode?: boolean } 
 
   useEffect(() => {
     if (demoMode || !activeWsId) return;
+    // Don't save until this workspace's state has actually loaded
+    if (hydratedWsRef.current !== activeWsId) return;
     saveSovereignValue(storageKeyForWorkspace(activeWsId), state);
     // Update workspace brandName if changed
     if (state.brand.brandName) {


### PR DESCRIPTION
The autosave effect fires on every [state, activeWsId] change, including the initial mount and workspace switches — before the async state load for that workspace has resolved. This races the load: defaultState gets persisted over the workspace's real data.

With local IndexedDB the race was usually won by the load (IDB op ordering), but with cloud sync enabled (v1.2.0) both load and save are network calls, and the empty defaultState regularly wins — overwriting the workspace state in Supabase and, via the IDB mirror write, locally too. Once the cloud copy is clobbered it keeps winning on every reload, because cloud is read first.

Fix: track which workspace has finished hydrating in a ref; skip autosave for a workspace until its load completes.